### PR TITLE
[COP-32] HeaderTool: fix parsing of `using namespace Name;` expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 # Visual Studio
 *.user
+launchSettings.json


### PR DESCRIPTION
Closes #32